### PR TITLE
Create 0xa10-multiple-verbs-exposure.md

### DIFF
--- a/2019/en/src/0xa10-multiple-verbs-exposure.md
+++ b/2019/en/src/0xa10-multiple-verbs-exposure.md
@@ -1,0 +1,6 @@
+By default, APIs do not restrict/limit the HTTP Verbs/Methods by which they can be accessed. In rare occasions, depending on how secure the server was or is setup, a sophisticated attacker may be able to use HEAD to leak information/secrets on the server.
+
+API developers should ensure that APIs they build can only be accessed by the prescribed and specified HTTP verbs. All other verbs should not be permitted.  
+
+Nathan Aw
+(Singapore)


### PR DESCRIPTION
Hello! In my course of work as an API developer, I discovered that security of a server can be compromised when multiple HTTP methods (verbs) are permitted, specifically HTTP HEAD. 

Therefore, I am strongly suggesting that multiple HTTP methods (verbs) be not allowed by default. Instead only the prescribed/specified HTTP verbs should be clearly defined and allowed on an API. 

E.g., 
Only GET, excluding HEAD
Only POST, excluding HEAD
Only HEAD
