### PR TITLE
Fix links that are redirecting to page not found on github

### DIFF
--- a/editions/2023/en/0x11-t10.md
+++ b/editions/2023/en/0x11-t10.md
@@ -13,9 +13,9 @@
 | [API9:2023 - Improper Inventory Management][api9] | APIs tend to expose more endpoints than traditional web applications, making proper and updated documentation highly important. A proper inventory of hosts and deployed API versions also are important to mitigate issues such as deprecated API versions and exposed debug endpoints. |
 | [API10:2023 - Unsafe Consumption of APIs][api10] | Developers tend to trust data received from third-party APIs more than user input, and so tend to adopt weaker security standards. In order to compromise APIs, attackers go after integrated third-party services instead of trying to compromise the target API directly. |
 
-[1]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa3-excessive-data-exposure.md
-[2]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md
-[3]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa4-lack-of-resources-and-rate-limiting.md
+[1]: https://owasp.org/API-Security/editions/2019/en/0xa3-excessive-data-exposure/
+[2]: https://owasp.org/API-Security/editions/2019/en/0xa6-mass-assignment/
+[3]: https://owasp.org/API-Security/editions/2019/en/0xa4-lack-of-resources-and-rate-limiting/
 [api1]: 0xa1-broken-object-level-authorization.md
 [api2]: 0xa2-broken-authentication.md
 [api3]: 0xa3-broken-object-property-level-authorization.md

--- a/editions/2023/en/0x11-t10.md
+++ b/editions/2023/en/0x11-t10.md
@@ -13,9 +13,9 @@
 | [API9:2023 - Improper Inventory Management][api9] | APIs tend to expose more endpoints than traditional web applications, making proper and updated documentation highly important. A proper inventory of hosts and deployed API versions also are important to mitigate issues such as deprecated API versions and exposed debug endpoints. |
 | [API10:2023 - Unsafe Consumption of APIs][api10] | Developers tend to trust data received from third-party APIs more than user input, and so tend to adopt weaker security standards. In order to compromise APIs, attackers go after integrated third-party services instead of trying to compromise the target API directly. |
 
-[1]: https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa3-excessive-data-exposure.md
-[2]: https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa6-mass-assignment.md
-[3]: https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa4-lack-of-resources-and-rate-limiting.md
+[1]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa3-excessive-data-exposure.md
+[2]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md
+[3]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa4-lack-of-resources-and-rate-limiting.md
 [api1]: 0xa1-broken-object-level-authorization.md
 [api2]: 0xa2-broken-authentication.md
 [api3]: 0xa3-broken-object-property-level-authorization.md

--- a/editions/2023/en/0xa3-broken-object-property-level-authorization.md
+++ b/editions/2023/en/0xa3-broken-object-property-level-authorization.md
@@ -144,8 +144,8 @@ content.
 * [CWE-213: Exposure of Sensitive Information Due to Incompatible Policies][4]
 * [CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes][5]
 
-[1]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa3-excessive-data-exposure.md
-[2]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md
+[1]: https://owasp.org/API-Security/editions/2019/en/0xa3-excessive-data-exposure/
+[2]: https://owasp.org/API-Security/editions/2019/en/0xa6-mass-assignment/
 [3]: https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html
 [4]: https://cwe.mitre.org/data/definitions/213.html
 [5]: https://cwe.mitre.org/data/definitions/915.html

--- a/editions/2023/en/0xa3-broken-object-property-level-authorization.md
+++ b/editions/2023/en/0xa3-broken-object-property-level-authorization.md
@@ -144,8 +144,8 @@ content.
 * [CWE-213: Exposure of Sensitive Information Due to Incompatible Policies][4]
 * [CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes][5]
 
-[1]: https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa3-excessive-data-exposure.md
-[2]: https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa6-mass-assignment.md
+[1]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa3-excessive-data-exposure.md
+[2]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xa6-mass-assignment.md
 [3]: https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html
 [4]: https://cwe.mitre.org/data/definitions/213.html
 [5]: https://cwe.mitre.org/data/definitions/915.html

--- a/editions/2023/en/0xa6-unrestricted-access-to-sensitive-business-flows.md
+++ b/editions/2023/en/0xa6-unrestricted-access-to-sensitive-business-flows.md
@@ -103,4 +103,5 @@ The mitigation planning should be done in two layers:
 * [API10:2019 Insufficient Logging & Monitoring][2]
 
 [1]: https://owasp.org/www-project-automated-threats-to-web-applications/
-[2]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xaa-insufficient-logging-monitoring.md
+[2]: https://owasp.org/API-Security/editions/2019/en/0xaa-insufficient-logging-monitoring/
+

--- a/editions/2023/en/0xa6-unrestricted-access-to-sensitive-business-flows.md
+++ b/editions/2023/en/0xa6-unrestricted-access-to-sensitive-business-flows.md
@@ -103,4 +103,4 @@ The mitigation planning should be done in two layers:
 * [API10:2019 Insufficient Logging & Monitoring][2]
 
 [1]: https://owasp.org/www-project-automated-threats-to-web-applications/
-[2]: https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xaa-insufficient-logging-monitoring.md
+[2]: https://github.com/OWASP/API-Security/blob/master/editions/2019/en/0xaa-insufficient-logging-monitoring.md


### PR DESCRIPTION
Some links are redirecting to a page not found. Example:

![image](https://github.com/OWASP/API-Security/assets/50708795/d31f2596-2bf4-4665-9e91-894675ee98df)

So I made the correction passing the right url:
![image](https://github.com/OWASP/API-Security/assets/50708795/efab7fe7-efa5-41aa-ad65-fba1a669595d)

