### PR TITLE
Fix risk rating doc

### DIFF
--- a/editions/2023/en/0xd0-about-data.md
+++ b/editions/2023/en/0xd0-about-data.md
@@ -37,8 +37,7 @@ threats to get insights into how victims are impacted and how those threats can
 be mitigated.
 
 This effort resulted in an initial draft of what the team believes were the ten
-most critical API security risks. The [OWASP Risk Rating Methodology][2] was
-used to perform the risk analysis. Prevalence ratings were decided from a
+most critical API security risks.The [OWASP Risk Rating Methodology][2] was used to perform the risk analysis. The OWASP Risk Rating Methodology incorporates risk assessment concepts and references the [OWASP Risk Assessment Framework][8] project, which provides guidance on assessing and prioritizing risks.. Prevalence ratings were decided from a
 consensus among the project team members, based on their experience in the
 field. For considerations on these matters, please refer to the [API Security
 Risks][3] section.
@@ -71,3 +70,4 @@ attention in APIs.
 [5]: https://github.com/OWASP/API-Security/issues?q=is%3Aissue+label%3A2023RC
 [6]: https://github.com/OWASP/API-Security/pulls?q=is%3Apr+label%3A2023RC
 [7]: ./0xd1-acknowledgments.md
+[8]: https://owasp.org/www-project-risk-assessment-framework/

--- a/editions/2023/en/0xd0-about-data.md
+++ b/editions/2023/en/0xd0-about-data.md
@@ -37,7 +37,7 @@ threats to get insights into how victims are impacted and how those threats can
 be mitigated.
 
 This effort resulted in an initial draft of what the team believes were the ten
-most critical API security risks.The [OWASP Risk Rating Methodology][2] was used to perform the risk analysis. The OWASP Risk Rating Methodology incorporates risk assessment concepts and references the [OWASP Risk Assessment Framework][8] project, which provides guidance on assessing and prioritizing risks.. Prevalence ratings were decided from a
+most critical API security risks.The [OWASP Risk Rating Methodology][2] was used to perform the risk analysis. The OWASP Risk Rating Methodology incorporates risk assessment concepts and references the [OWASP Risk Assessment Framework][8] project, which provides guidance on assessing and prioritizing risks. Prevalence ratings were decided from a
 consensus among the project team members, based on their experience in the
 field. For considerations on these matters, please refer to the [API Security
 Risks][3] section.


### PR DESCRIPTION
This PR clarifies the relationship between the OWASP Risk Rating Methodology and the OWASP Risk Assessment Framework in the 2023 API Security documentation.

## Changes

- Added clarification text about how risk assessment relates to risk rating.
- Added a reference link to the OWASP Risk Assessment Framework project.

Documentation-only change.
