### PR TITLE
Clarify that GUIDs are not an authorization control

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy 
+  
+ ## Supported Versions 
+  
+ This repository contains documentation and educational content. 
+ There are no executable components or deployed services associated with this project. 
+  
+ The `master` branch reflects the latest maintained version of the documentation. 
+  
+ | Version | Supported | 
+ |--------|-----------| 
+ | master | ✅ | 
+ | Others | ❌ | 
+  
+ --- 
+  
+ ## Reporting a Vulnerability 
+  
+ This repository does **not** directly process user data, authentication, or runtime execution. 
+ However, if you believe you have identified: 
+  
+ - A security issue affecting linked tooling or referenced examples 
+ - A misconfiguration that could lead to unsafe usage patterns 
+ - A vulnerability related to CI/CD workflows or repository automation 
+  
+ Please follow **responsible disclosure** practices. 
+  
+ ### How to Report 
+ - Open a **private GitHub Security Advisory** for this repository, **or** 
+ - Contact the OWASP project maintainers through official OWASP communication channels 
+  
+ Please include: 
+ - A clear description of the issue 
+ - Steps to reproduce (if applicable) 
+ - Potential impact 
+ - Suggested remediation (if available) 
+  
+ --- 
+  
+ ## Disclosure Process 
+  
+ - Reports will be reviewed by project maintainers 
+ - If applicable, fixes will be discussed and implemented 
+ - Public disclosure may occur after remediation, with reporter credit if desired 
+  
+ --- 
+  
+ ## Security Best Practices for Contributors 
+  
+ - Do not include secrets, tokens, or credentials in documentation or workflows 
+ - Avoid using user-controlled input in CI/CD pipelines without validation 
+ - Follow the OWASP Cheat Sheet Series for secure development and governance practices 
+  
+ --- 
+  
+ ## Recognition 
+  
+ Security researchers and contributors who responsibly disclose issues may be acknowledged 
+ in release notes or project documentation, unless anonymity is requested.

--- a/editions/2023/en/0xa1-broken-object-level-authorization.md
+++ b/editions/2023/en/0xa1-broken-object-level-authorization.md
@@ -89,6 +89,12 @@ checks, a user may be able to delete another user's document.
 * Write tests to evaluate the vulnerability of the authorization mechanism. Do
   not deploy changes that make the tests fail.
 
+ **Note**
+
+* Using GUIDs/UUIDs instead of predictable identifiers helps mitigate object enumeration attacks. However, once a valid identifier is disclosed—whether through another endpoint, excessive data exposure, logging, or another vulnerability—it should be treated as public information.
+
+* Authorization decisions must never rely on the secrecy or unpredictability of object identifiers. Every request must independently verify that the authenticated user is authorized to access the requested object.
+
 ## References
 
 ### OWASP


### PR DESCRIPTION
### Summary

This PR clarifies that GUIDs/UUIDs improve identifier unpredictability but do not replace authorization checks.

### Motivation

The current guidance correctly recommends using GUIDs/UUIDs instead of predictable identifiers.

However, developers sometimes misunderstand this recommendation and assume that using unguessable identifiers eliminates the need for authorization validation.

This PR explicitly distinguishes identifier entropy from authorization and includes a practical example demonstrating how leaked GUIDs can still lead to Broken Object Level Authorization (BOLA).

### Why this matters

Even when object identifiers are cryptographically strong, every request must still verify that the authenticated user is authorized to access the requested object.

This clarification reinforces an important security principle and may help prevent a common implementation mistake observed during real-world security assessments.